### PR TITLE
Fixed the interactive_environments' image to show up

### DIFF
--- a/doc/source/admin/interactive_environments.rst
+++ b/doc/source/admin/interactive_environments.rst
@@ -21,7 +21,7 @@ into Galaxy which helps coordinate a 1:1 mapping of users and their docker conta
 
 Here's a simple diagram recapping the above:
 
-.. image:: interactive_environments.*
+.. image:: interactive_environments.png
 
 Deploying GIEs
 --------------


### PR DESCRIPTION
The .\* did not do the trick, added the .png extension so we could see the image.

There is still the "interactive_environments_success.png" missing though! If you want me to take the picture, I can. Just need to know exactly what you want to show :p
